### PR TITLE
Make commands handle URLs, upload multiple files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,9 +52,10 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "catbox"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "clap",
+ "regex",
  "reqwest",
  "sha2",
  "tempfile",
@@ -650,6 +660,23 @@ checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "catbox"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
 clap = { version = "*", default-features = false }
+regex = "*"
 reqwest = { version = "*", features = ["multipart", "stream"] }
 tokio = { version = "*", features = ["full"] }
 tokio-util = { version = "*", features = ["io"] }

--- a/README.md
+++ b/README.md
@@ -58,9 +58,16 @@ Upload a file:
 catbox upload cute_picture.png
 ```
 
+Upload multiple files:
+```
+catbox upload *.jpg  # Upload all jpg files
+catbox upload image.png file.txt  # Upload image.png and file.txt
+```
+
 Delete a file:
 ```
 catbox delete abc123.jpg --user 1234567890123456789012345
+catbox delete https://files.catbox.moe/123456.png
 ```
 
 Create an album:

--- a/src/args.rs
+++ b/src/args.rs
@@ -6,8 +6,8 @@ pub fn get_app() -> clap::App<'static, 'static> {
         .subcommand(
             SubCommand::with_name("upload")
                 .about("Upload to Catbox. Max size 200MB.")
-                .arg(Arg::with_name("filepath").required(true).takes_value(true))
-                .arg(Arg::with_name("user hash").long("user").short("u").takes_value(true)),
+                .arg(Arg::with_name("user hash").long("user").short("u").takes_value(true))
+                .arg(Arg::with_name("files").required(true).takes_value(true).multiple(true)),
         )
         .subcommand(
             SubCommand::with_name("delete")
@@ -70,13 +70,7 @@ pub fn get_app() -> clap::App<'static, 'static> {
                 .subcommand(
                     SubCommand::with_name("delete")
                         .about("Delete an album")
-                        .arg(
-                            Arg::with_name("short")
-                                .long("short")
-                                .short("s")
-                                .required(true)
-                                .takes_value(true),
-                        )
+                        .arg(Arg::with_name("short").required(true).takes_value(true))
                         .arg(Arg::with_name("user hash").long("user").short("u").takes_value(true)),
                 ),
         )


### PR DESCRIPTION
Commands handling files already existing on catbox will now accept
and url to the file in addition to the simple 'short'. The upload
command will now accept multiple files and upload all of them
separately.